### PR TITLE
Enhance plugin lifecycle with join state

### DIFF
--- a/scripts/anticheat.js
+++ b/scripts/anticheat.js
@@ -641,6 +641,26 @@ class AnticheatSystem {
         this.reset();
     }
 
+    onEnable(joinState) {
+        this.reset();
+        if (joinState && Array.isArray(joinState.playerInfo)) {
+            for (const [uuid, info] of joinState.playerInfo) {
+                this.uuidToName.set(uuid, info.name || uuid);
+                this.uuidToDisplayName.set(uuid, info.displayName || info.name || uuid);
+            }
+        }
+        if (joinState && Array.isArray(joinState.entityData)) {
+            for (const [id, ent] of joinState.entityData) {
+                const player = new PlayerData(this.uuidToName.get(ent.uuid) || '', ent.uuid, id);
+                if (ent.position) {
+                    player.updatePosition(ent.position.x, ent.position.y, ent.position.z, ent.onGround, ent.yaw, ent.pitch);
+                }
+                this.players.set(ent.uuid, player);
+                this.entityToPlayer.set(id, player);
+            }
+        }
+    }
+
     reset() {
         this.players.clear();
         this.entityToPlayer.clear();

--- a/scripts/denicker.js
+++ b/scripts/denicker.js
@@ -105,6 +105,24 @@ class DenickerSystem {
         this.playerTeams.clear();
     }
 
+    onDisable() {
+        this.reset();
+    }
+
+    onEnable(joinState) {
+        this.reset();
+        if (joinState && Array.isArray(joinState.teamData)) {
+            for (const [team, info] of joinState.teamData) {
+                this.teamData.set(team, info);
+            }
+        }
+        if (joinState && Array.isArray(joinState.playerTeams)) {
+            for (const [playerName, teamName] of joinState.playerTeams) {
+                this.playerTeams.set(playerName, teamName);
+            }
+        }
+    }
+
     registerHandlers() {
         this.proxyAPI.on('serverPacketMonitor', ({ data, meta }) => {
             if (!this.proxyAPI.isPluginEnabled('denicker')) return;

--- a/src/game-state.js
+++ b/src/game-state.js
@@ -1,0 +1,186 @@
+class GameState {
+    constructor() {
+        this.reset();
+    }
+
+    reset() {
+        this.loginPacket = null;
+        this.playerInfo = new Map();
+        this.teamData = new Map();
+        this.playerTeams = new Map();
+        this.entityData = new Map();
+    }
+
+    setLoginPacket(packet) {
+        this.loginPacket = packet;
+    }
+
+    /**
+     * Updates stored state using server packet data
+     * @param {string} metaName - Packet name
+     * @param {object} data - Packet data
+     */
+    updateFromServerPacket(metaName, data) {
+        switch (metaName) {
+            case 'player_info':
+                if (data.data && Array.isArray(data.data)) {
+                    for (const entry of data.data) {
+                        const existing = this.playerInfo.get(entry.UUID) || {};
+                        if (entry.name) existing.name = entry.name;
+                        if (entry.displayName) existing.displayName = entry.displayName;
+                        this.playerInfo.set(entry.UUID, existing);
+                    }
+                }
+                break;
+            case 'scoreboard_team':
+                this._handleScoreboardTeam(data);
+                break;
+            case 'named_entity_spawn':
+                this.entityData.set(data.entityId, {
+                    uuid: data.playerUUID,
+                    position: { x: data.x / 32, y: data.y / 32, z: data.z / 32 },
+                    yaw: data.yaw,
+                    pitch: data.pitch,
+                    onGround: true
+                });
+                break;
+            case 'entity_destroy':
+                if (Array.isArray(data.entityIds)) {
+                    for (const id of data.entityIds) this.entityData.delete(id);
+                }
+                break;
+            case 'rel_entity_move':
+            case 'entity_move_look':
+            case 'entity_look':
+                this._updateEntityMovement(metaName, data);
+                break;
+            case 'entity_teleport':
+                this._teleportEntity(data);
+                break;
+        }
+    }
+
+    _handleScoreboardTeam(data) {
+        const { mode, team: teamName, players, prefix, suffix } = data;
+        if (mode === 0 || mode === 2) {
+            this.teamData.set(teamName, { prefix: prefix || '', suffix: suffix || '' });
+            if (Array.isArray(players)) {
+                for (const p of players) {
+                    const clean = p.replace(/§./g, '');
+                    this.playerTeams.set(clean, teamName);
+                }
+            }
+        }
+        if (mode === 3 && Array.isArray(players)) {
+            for (const p of players) {
+                const clean = p.replace(/§./g, '');
+                this.playerTeams.set(clean, teamName);
+            }
+        }
+        if (mode === 4 && Array.isArray(players)) {
+            for (const p of players) {
+                const clean = p.replace(/§./g, '');
+                this.playerTeams.delete(clean);
+            }
+        }
+        if (mode === 1) {
+            this.teamData.delete(teamName);
+            for (const [playerName, team] of Array.from(this.playerTeams.entries())) {
+                if (team === teamName) this.playerTeams.delete(playerName);
+            }
+        }
+    }
+
+    _updateEntityMovement(type, data) {
+        const ent = this.entityData.get(data.entityId);
+        if (!ent) return;
+        if (type === 'rel_entity_move' || type === 'entity_move_look') {
+            ent.position.x += data.dX / 32;
+            ent.position.y += data.dY / 32;
+            ent.position.z += data.dZ / 32;
+            ent.onGround = data.onGround;
+        }
+        if (type === 'entity_move_look' || type === 'entity_look') {
+            ent.yaw = (data.yaw / 256) * 360;
+            ent.pitch = (data.pitch / 256) * 360;
+        }
+    }
+
+    _teleportEntity(data) {
+        const ent = this.entityData.get(data.entityId);
+        if (!ent) return;
+        ent.position = { x: data.x / 32, y: data.y / 32, z: data.z / 32 };
+        ent.yaw = (data.yaw / 256) * 360;
+        ent.pitch = (data.pitch / 256) * 360;
+        ent.onGround = data.onGround;
+    }
+
+    /** Convenience getter for a player's info by UUID */
+    getPlayerInfo(uuid) {
+        return this.playerInfo.get(uuid);
+    }
+
+    /** Returns team metadata by team name */
+    getTeamData(teamName) {
+        return this.teamData.get(teamName);
+    }
+
+    /** Returns a player's team name */
+    getPlayerTeam(playerName) {
+        return this.playerTeams.get(playerName);
+    }
+
+    /** Returns entity metadata by ID */
+    getEntityData(entityId) {
+        return this.entityData.get(entityId);
+    }
+
+    /** Returns the formatted display name for a player UUID */
+    getDisplayName(uuid) {
+        const info = this.playerInfo.get(uuid);
+        if (!info) return null;
+
+        let name = info.name || uuid;
+        if (info.displayName) {
+            try {
+                const parsed = JSON.parse(info.displayName);
+                name = this._extractTextFromJSON(parsed);
+            } catch (e) {
+                name = info.displayName;
+            }
+        }
+
+        const clean = name.replace(/§./g, '');
+        const teamName = this.playerTeams.get(clean);
+        const team = teamName ? this.teamData.get(teamName) : null;
+
+        return team ? `${team.prefix}${name}${team.suffix}` : name;
+    }
+
+    _extractTextFromJSON(node) {
+        if (typeof node === 'string') return node;
+        if (!node) return '';
+        let result = node.text || '';
+        if (Array.isArray(node.extra)) {
+            for (const child of node.extra) {
+                result += this._extractTextFromJSON(child);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns a plain object snapshot of current join state
+     */
+    getSnapshot() {
+        return {
+            loginPacket: this.loginPacket,
+            playerInfo: Array.from(this.playerInfo.entries()),
+            teamData: Array.from(this.teamData.entries()),
+            playerTeams: Array.from(this.playerTeams.entries()),
+            entityData: Array.from(this.entityData.entries())
+        };
+    }
+}
+
+module.exports = GameState;

--- a/src/plugin-api.js
+++ b/src/plugin-api.js
@@ -1,0 +1,114 @@
+const EventEmitter = require('events');
+
+const PROXY_NAME = '§6S§eta§fr§bfi§3sh §5Proxy§r';
+const PROXY_PREFIX = '§6S§eta§fr§bfi§3sh';
+
+class PluginAPI extends EventEmitter {
+    constructor(proxyManager) {
+        super();
+        this.proxyManager = proxyManager;
+    }
+
+    get currentPlayer() {
+        return this.proxyManager.currentPlayer;
+    }
+
+    get proxyName() {
+        return PROXY_NAME;
+    }
+
+    get proxyPrefix() {
+        return PROXY_PREFIX;
+    }
+
+    sendToClient(metaName, data) {
+        if (!this.currentPlayer?.client) return false;
+        this.currentPlayer.client.write(metaName, data);
+        return true;
+    }
+
+    sendToServer(metaName, data) {
+        if (!this.currentPlayer?.targetClient) return false;
+        this.currentPlayer.targetClient.write(metaName, data);
+        return true;
+    }
+
+    sendChatMessage(client, message) {
+        return this.proxyManager.sendChatMessage(client, message);
+    }
+
+    registerPlugin(pluginInfo) {
+        return this.proxyManager.pluginManager.registerPlugin(pluginInfo);
+    }
+
+    setPluginEnabled(pluginName, enabled) {
+        return this.proxyManager.pluginManager.setPluginEnabled(pluginName, enabled);
+    }
+
+    isPluginEnabled(pluginName) {
+        return this.proxyManager.pluginManager.isPluginEnabled(pluginName);
+    }
+
+    setPluginDebug(pluginName, debug) {
+        return this.proxyManager.pluginManager.setPluginDebug(pluginName, debug);
+    }
+
+    isPluginDebugEnabled(pluginName) {
+        return this.proxyManager.pluginManager.isPluginDebugEnabled(pluginName);
+    }
+
+    getAllPluginStates() {
+        return this.proxyManager.pluginManager.getAllPluginStates();
+    }
+
+    getLoadedPlugins() {
+        return this.proxyManager.pluginManager.getLoadedPlugins();
+    }
+
+    getJoinState() {
+        return this.proxyManager.getJoinState();
+    }
+
+    getPlayerInfo(uuid) {
+        return this.proxyManager.gameState.getPlayerInfo(uuid);
+    }
+
+    getTeamData(teamName) {
+        return this.proxyManager.gameState.getTeamData(teamName);
+    }
+
+    getPlayerTeam(playerName) {
+        return this.proxyManager.gameState.getPlayerTeam(playerName);
+    }
+
+    getEntityData(entityId) {
+        return this.proxyManager.gameState.getEntityData(entityId);
+    }
+
+    getDisplayName(uuid) {
+        return this.proxyManager.gameState.getDisplayName(uuid);
+    }
+
+    emit(eventName, ...args) {
+        const listeners = this.listeners(eventName);
+        const enabledListeners = this.proxyManager.pluginManager.filterEnabledListeners(listeners);
+        enabledListeners.forEach(listener => {
+            try {
+                listener(...args);
+            } catch (error) {
+                console.error('Error in event listener:', error);
+            }
+        });
+        return this.listenerCount(eventName) > 0;
+    }
+
+    registerCommands(moduleName, commands) {
+        this.proxyManager.commandHandler.register(moduleName, commands);
+    }
+
+    kickPlayer(reason) {
+        this.proxyManager.kickPlayer(reason);
+    }
+}
+
+module.exports = { PluginAPI, PROXY_NAME, PROXY_PREFIX };


### PR DESCRIPTION
## Summary
- invoke plugin `onEnable` when registered and when enabled
- preserve event listeners when plugins change their name at registration
- expose game state utilities through `PluginAPI`
- track scoreboard/team data and compute player display names

## Testing
- `node -e "require('./src/game-state.js'); console.log('loaded');"`
- `node -e "require('./src/plugin-api.js'); console.log('api loaded');"`
- `node -e "require('./src/plugin-manager.js'); console.log('pm loaded');"`
- `node -e "const proxy=require('./src/proxy.js');" >/tmp/proxy_log & sleep 2; pkill -f 'src/proxy.js'; cat /tmp/proxy_log`


------
https://chatgpt.com/codex/tasks/task_e_6854a7e4e3bc8330b36dbe7b4fdb62da